### PR TITLE
Some jshint fixes + using jquery-1.9.0

### DIFF
--- a/jquery.subwayMap-0.5.0.js
+++ b/jquery.subwayMap-0.5.0.js
@@ -67,25 +67,25 @@ THE SOFTWARE.
 
         this.layer = -1;
         var rows = el.attr("data-rows");
-        if (rows === undefined) 
+        if (rows === undefined)
             rows = 10;
         else
             rows = parseInt(rows);
 
         var columns = el.attr("data-columns");
-        if (columns === undefined) 
+        if (columns === undefined)
             columns = 10;
         else
             columns = parseInt(columns);
 
         var scale = el.attr("data-cellSize");
-        if (scale === undefined) 
+        if (scale === undefined)
             scale = 100;
         else
             scale = parseInt(scale);
 
         var lineWidth = el.attr("data-lineWidth");
-        if (lineWidth === undefined) 
+        if (lineWidth === undefined)
             lineWidth = 10;
         else
             lineWidth = parseInt(lineWidth);
@@ -133,7 +133,7 @@ THE SOFTWARE.
                 if (color === undefined) color = "#000000";
 
                 var lineTextClass = $(ul).attr("data-textClass");
-                if (lineTextClass === undefined) lineTextClass = "";                
+                if (lineTextClass === undefined) lineTextClass = "";
 
                 var shiftCoords = $(ul).attr("data-shiftCoords");
                 if (shiftCoords === undefined) shiftCoords = "";
@@ -146,7 +146,7 @@ THE SOFTWARE.
                 }
 
                 var lineLabel = $(ul).attr("data-label");
-                if (lineLabel === undefined) 
+                if (lineLabel === undefined)
                     lineLabel = "Line " + index;
 
                 lineLabels[lineLabels.length] = {label: lineLabel, color: color};
@@ -214,7 +214,8 @@ THE SOFTWARE.
         ctx.moveTo(nodes[0].x * scale, nodes[0].y * scale);
         var markers = [];
         var lineNodes = [];
-        for(var node = 0; node < nodes.length; node++)
+        var node;
+        for(node = 0; node < nodes.length; node++)
         {
             if (nodes[node].marker.indexOf("@") != 0)
                 lineNodes[lineNodes.length] = nodes[node];
@@ -277,7 +278,7 @@ THE SOFTWARE.
                         case "ne": xVal = (scale / 2); yVal = 1; dirVal = -1; break;
                     }
                     this._debug((currNode.x * scale) + xVal + ", " + (currNode.y * scale) + "; " + (nextNode.x + (dirVal * xDiff / 2)) * scale + ", " +
-                    (nextNode.y + (yVal * xDiff / 2)) * scale)
+                    (nextNode.y + (yVal * xDiff / 2)) * scale);
                     ctx.bezierCurveTo(
                             (currNode.x * scale) + xVal, (currNode.y * scale),
                             (currNode.x * scale) + xVal, (currNode.y * scale),
@@ -290,14 +291,14 @@ THE SOFTWARE.
                 else
                     ctx.lineTo(nextNode.x * scale, nextNode.y * scale);
             }
-        } 
+        }
 
         ctx.strokeStyle = color;
         ctx.lineWidth = width;
         ctx.stroke();
 
         ctx = this._getCanvasLayer(el, true);
-        for (var node = 0; node < nodes.length; node++) {
+        for (node = 0; node < nodes.length; node++) {
             this._drawMarker(el, ctx, scale, color, textClass, width, nodes[node], reverseMarkers);
         }
 
@@ -362,7 +363,7 @@ THE SOFTWARE.
         ctx.closePath();
         ctx.stroke();
         ctx.fill();
-        
+
         // Render text labels and hyperlinks
         var pos = "";
         var offset = width + 4;
@@ -405,8 +406,8 @@ THE SOFTWARE.
         if (data.link != "")
             $("<a " + style + " title='" + data.title.replace(/\\n/g,"<br />") + "' href='" + data.link + "' target='_new'>" + data.label.replace(/\\n/g,"<br />") + "</span>").appendTo(el);
         else
-            $("<span " + style + ">" + data.label.replace(/\\n/g,"<br />") + "</span>").appendTo(el);;
-        
+            $("<span " + style + ">" + data.label.replace(/\\n/g,"<br />") + "</span>").appendTo(el);
+
     },
     _drawGrid: function (el, scale, gridNumbers) {
 
@@ -445,7 +446,7 @@ THE SOFTWARE.
         ctx.closePath();
 
     }
-}
+};
 
 var methods = {
 
@@ -469,7 +470,7 @@ var methods = {
     },
     drawLine: function (data) {
         plugin._drawLine(data.element, data.scale, data.rows, data.columns, data.color, data.width, data.nodes);
-    },
+    }
 };
 
 $.fn.subwayMap = function (method) {

--- a/subwayMap.htm
+++ b/subwayMap.htm
@@ -1,7 +1,7 @@
 ﻿<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <title>Subway Map</title>
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.4.2.min.js"></script>
+    <script type="text/javascript" src="http://code.jquery.com/jquery-1.9.0.min.js"></script>
     <script type="text/javascript" src="jquery.subwayMap-0.5.0.js"></script>
     <style type="text/css">
     body


### PR DESCRIPTION
Added semicolons.
Upgrade to jquery-1.9.0.
Define var node more explicit.
Removed double ; and trailing ,

jshint reports a lot issues but I only fixed the trivial ones.

```
# jshint.before.txt
jquery.subwayMap-0.5.0.js: line 41, col 45, Unreachable 'break' after 'return'.
jquery.subwayMap-0.5.0.js: line 42, col 49, Unreachable 'break' after 'return'.
jquery.subwayMap-0.5.0.js: line 73, col 33, Missing radix parameter.
jquery.subwayMap-0.5.0.js: line 79, col 39, Missing radix parameter.
jquery.subwayMap-0.5.0.js: line 85, col 35, Missing radix parameter.
jquery.subwayMap-0.5.0.js: line 91, col 43, Missing radix parameter.
jquery.subwayMap-0.5.0.js: line 144, col 64, Missing radix parameter.
jquery.subwayMap-0.5.0.js: line 145, col 64, Missing radix parameter.
jquery.subwayMap-0.5.0.js: line 167, col 32, Use '===' to compare with 'undefined'.
jquery.subwayMap-0.5.0.js: line 170, col 36, Use '===' to compare with 'undefined'.
jquery.subwayMap-0.5.0.js: line 178, col 32, Use '!==' to compare with 'undefined'.
jquery.subwayMap-0.5.0.js: line 196, col 84, Use '!==' to compare with ''.
jquery.subwayMap-0.5.0.js: line 200, col 54, Use '!==' to compare with ''.
jquery.subwayMap-0.5.0.js: line 219, col 49, Use '!==' to compare with '0'.
jquery.subwayMap-0.5.0.js: line 230, col 32, Use '===' to compare with '0'.
jquery.subwayMap-0.5.0.js: line 232, col 32, Use '===' to compare with '0'.
jquery.subwayMap-0.5.0.js: line 241, col 28, Use '===' to compare with '0'.
jquery.subwayMap-0.5.0.js: line 241, col 44, Use '===' to compare with '0'.
jquery.subwayMap-0.5.0.js: line 247, col 44, Use '!==' to compare with ''.
jquery.subwayMap-0.5.0.js: line 280, col 63, Missing semicolon.
jquery.subwayMap-0.5.0.js: line 300, col 23, 'node' is already defined.
jquery.subwayMap-0.5.0.js: line 308, col 24, Use '===' to compare with ''.
jquery.subwayMap-0.5.0.js: line 309, col 25, Use '===' to compare with ''.
jquery.subwayMap-0.5.0.js: line 333, col 37, Use '===' to compare with ''.
jquery.subwayMap-0.5.0.js: line 338, col 70, Missing radix parameter.
jquery.subwayMap-0.5.0.js: line 404, col 32, Use '!==' to compare with ''.
jquery.subwayMap-0.5.0.js: line 404, col 100, Use '===' to compare with ''.
jquery.subwayMap-0.5.0.js: line 404, col 223, Use '!==' to compare with ''.
jquery.subwayMap-0.5.0.js: line 405, col 23, Use '!==' to compare with ''.
jquery.subwayMap-0.5.0.js: line 408, col 102, Unnecessary semicolon.
jquery.subwayMap-0.5.0.js: line 448, col 2, Missing semicolon.
jquery.subwayMap-0.5.0.js: line 459, col 37, Bad line breaking before '?'.
jquery.subwayMap-0.5.0.js: line 472, col 6, Extra comma. (it breaks older versions of IE)
```
