### PR TITLE
subwayMapJS: make it working on IE9

### DIFF
--- a/jquery.subwayMap-0.5.0.js
+++ b/jquery.subwayMap-0.5.0.js
@@ -120,7 +120,7 @@ THE SOFTWARE.
 
         //el.css("width", this.options.pixelWidth);
         //el.css("height", this.options.pixelHeight);
-        self = this;
+        var self = this;
         var lineLabels = [];
         var supportsCanvas = $("<canvas></canvas>")[0].getContext;
         if (supportsCanvas) {


### PR DESCRIPTION
Hi!

This PR fix a little bug which broke subwayJS on IE9.
(Error was: `self._debug: Object doesn't support property or method '_debug'`)

Thanks for making this nice plugin!
