### PR TITLE
Add outline effect to the legend and increased version number

### DIFF
--- a/jquery.subwayMap-0.5.1.js
+++ b/jquery.subwayMap-0.5.1.js
@@ -157,7 +157,7 @@ THE SOFTWARE.
                 if (lineLabel === undefined)
                     lineLabel = "Line " + index;
 
-                lineLabels[lineLabels.length] = {label: lineLabel, color: color};
+                lineLabels[lineLabels.length] = {label: lineLabel, color: color, outline: outline};
 
                 var nodes = [];
                 $(ul).children("li").each(function () {
@@ -217,8 +217,17 @@ THE SOFTWARE.
             {
                 var legend = $("#" + legendId);
 
-                for(var line=0; line<lineLabels.length; line++)
-                    legend.append("<div><span style='float:left;width:100px;height:" + lineWidth + "px;background-color:" + lineLabels[line].color + "'></span>" + lineLabels[line].label + "</div>");
+                for(var line=0; line<lineLabels.length; line++) {
+                 
+                    // Create a SVG rect for the line
+                    var lineSVG = "<rect x='0' y='0' width='100' height='"+lineWidth+"' fill='" + lineLabels[line].color + "' />";
+                    
+                    // We create a second SVG white rect to create the outline effect in the legend if required by the "outline" param
+                    if (lineLabels[line].outline === true) 
+                        lineSVG += "<rect x='0' y='1' width='100' height='"+ (lineWidth - 2) +"' fill='#FFFFFF' />";
+                 
+                    legend.append("<div><span style='float:left; display:bock;width:100px;height:" + lineWidth + "px;'><svg>" + lineSVG + "</svg></span>" + lineLabels[line].label + "</div>");
+                }  
             }
 
         }

--- a/jquery.subwayMap-0.5.2.js
+++ b/jquery.subwayMap-0.5.2.js
@@ -163,7 +163,7 @@ THE SOFTWARE.
                 if (lineLabel === undefined)
                     lineLabel = "Line " + index;
 
-                lineLabels[lineLabels.length] = {label: lineLabel, color: color, outline: outline};
+                lineLabels[lineLabels.length] = {label: lineLabel, color: color, outline: outline, dotted: dotted };
 
                 var nodes = [];
                 $(ul).children("li").each(function () {
@@ -222,12 +222,17 @@ THE SOFTWARE.
 
                 for(var line=0; line<lineLabels.length; line++) {
                  
-                    // Create a SVG rect for the line
-                    var lineSVG = "<rect x='0' y='0' width='100' height='"+lineWidth+"' fill='" + lineLabels[line].color + "' />";
+                    // Prepare SVG param for dotted lines
+                    var dottedSVGParam = "";
+                    if (lineLabels[line].dotted === true) 
+                        dottedSVGParam = "stroke-dasharray='5, 5'";
+
+                    // Create a SVG line
+                    var lineSVG = "<line x1='0' y1='3' x2='100' y2='3' stroke-width='"+ (lineWidth + 2)  +"' stroke='" + lineLabels[line].color + "' "+ dottedSVGParam +" />";
                     
-                    // We create a second SVG white rect to create the outline effect in the legend if required by the "outline" param
+                    // We create a second SVG white line to create the outline effect in the legend if required by the "outline" param
                     if (lineLabels[line].outline === true) 
-                        lineSVG += "<rect x='0' y='1' width='100' height='"+ (lineWidth - 2) +"' fill='#FFFFFF' />";
+                        lineSVG += "<line x1='0' y1='4' x2='100' y2='4' stroke-width='"+ ( (lineWidth + 2) / 2 ) +"' stroke='#FFFFFF' "+ dottedSVGParam +" />";
                  
                     legend.append("<div><span style='float:left; display:bock;width:100px;height:" + lineWidth + "px;'><svg>" + lineSVG + "</svg></span>" + lineLabels[line].label + "</div>");
                 }  

--- a/jquery.subwayMap-0.5.2.js
+++ b/jquery.subwayMap-0.5.2.js
@@ -140,6 +140,12 @@ THE SOFTWARE.
                 else 
                     outline = false;
 
+                var dotted = $(ul).attr("data-dotted");
+                if (dotted != undefined && ((dotted === true) || (dotted.toLowerCase() == "true")))
+                    dotted = true;
+                else 
+                    dotted = false;
+
                 var lineTextClass = $(ul).attr("data-textClass");
                 if (lineTextClass === undefined) lineTextClass = "";
 
@@ -176,10 +182,7 @@ THE SOFTWARE.
 
                     var markerInfo = $(this).attr("data-markerInfo");
                     if (markerInfo == undefined) markerInfo = "";
-                    
-                    var dotted = $(this).attr("data-dotted-line");
-                    if (dotted == undefined) dotted = "false";
-                    
+
                     var anchor = $(this).children("a:first-child");
                     var label = $(this).text();
                     if (label === undefined) label = "";
@@ -193,7 +196,7 @@ THE SOFTWARE.
                         if (title === undefined) title = "";
                     }
 
-                    self._debug("Coords=" + coords + "; Dir=" + dir + "; Link=" + link + "; Label=" + label + "; labelPos=" + labelPos + "; Marker=" + marker + "; Dotted=" + dotted);
+                    self._debug("Coords=" + coords + "; Dir=" + dir + "; Link=" + link + "; Label=" + label + "; labelPos=" + labelPos + "; Marker=" + marker);
 
                     var x = "";
                     var y = "";
@@ -201,13 +204,13 @@ THE SOFTWARE.
                         x = Number(coords.split(",")[0]) + (marker.indexOf("interchange") > -1 ? 0 : shiftX);
                         y = Number(coords.split(",")[1]) + (marker.indexOf("interchange") > -1 ? 0 : shiftY);
                     }
-                    nodes[nodes.length] = { x: x, y: y, direction: dir, marker: marker, markerInfo: markerInfo, link: link, title: title, label: label, labelPos: labelPos, dotted: dotted };
+                    nodes[nodes.length] = { x: x, y: y, direction: dir, marker: marker, markerInfo: markerInfo, link: link, title: title, label: label, labelPos: labelPos };
                 });
 
                 if (nodes.length > 0) {
-                    self._drawLine(el, scale, rows, columns, color, (lineTextClass != "" ? lineTextClass : textClass), lineWidth, nodes, reverseMarkers);
+                    self._drawLine(el, scale, rows, columns, color, (lineTextClass != "" ? lineTextClass : textClass), lineWidth, nodes, reverseMarkers, dotted);
                     if (outline === true) 
-                        self._drawLine(el, scale, rows, columns, '#FFFFFF', false, lineWidth - 2, nodes, reverseMarkers);
+                        self._drawLine(el, scale, rows, columns, '#FFFFFF', false, lineWidth - 2, nodes, reverseMarkers, dotted);
                 }
                     
                 $(ul).remove();
@@ -232,7 +235,7 @@ THE SOFTWARE.
 
         }
     },
-    _drawLine: function (el, scale, rows, columns, color, textClass, width, nodes, reverseMarkers) {
+    _drawLine: function (el, scale, rows, columns, color, textClass, width, nodes, reverseMarkers, dotted) {
 
         var ctx = this._getCanvasLayer(el, false);
         ctx.beginPath();
@@ -318,7 +321,8 @@ THE SOFTWARE.
             }
         }
 
-        if (nodes[0].dotted == "true") { ctx.setLineDash([5, 5]); }
+        if (dotted === true) 
+            ctx.setLineDash([5, 5]);
         ctx.strokeStyle = color;
         ctx.lineWidth = width;
         ctx.stroke();

--- a/subwayMap.htm
+++ b/subwayMap.htm
@@ -51,7 +51,7 @@
 </head>
 <body>
     <div class="subway-map" data-columns="12" data-rows="10" data-cellSize="40" data-legendId="legend" data-textClass="text" data-gridNumbers="true" data-grid="false" data-lineWidth="8">
-        <ul data-color="#ff4db2" data-label="jQuery Widgets" data-outline="true">          
+        <ul data-color="#36AEFF" data-label="jQuery Widgets">          
             <li data-coords="2,2" data-marker="interchange"><a href="http://jqueryui.com/demos/accordion/">Accordion</a></li>  
             <li data-coords="4,2"><a href="http://jqueryui.com/demos/autocomplete/"><a href="http://jqueryui.com/demos/autocomplete/">Auto\ncomplete</a></li>  
             <li data-coords="5,3" data-dir="E"></li>  
@@ -72,7 +72,7 @@
             <li data-coords="2,6"><a href="http://jqueryui.com/demos/tabs/">Tabs</a></li>  
         </ul>
 
-        <ul data-color="#00ff00" data-label="jQuery Interactions" data-shiftCoords="0,-1">      
+        <ul data-color="#FF7936 " data-label="jQuery Interactions" data-shiftCoords="0,-1" data-outline="true">      
             <li data-coords="2,6"></li> 
             <li data-coords="2,5.9" data-marker="@interchange"> </li> <!-- marker-only node, moved up by 0.10 -->
             <li data-coords="5,6" data-marker="@station" data-labelPos="N"><a href="http://jqueryui.com/demos/selectable/">Selectable</a></li>  

--- a/subwayMap.htm
+++ b/subwayMap.htm
@@ -2,7 +2,7 @@
 <head>
     <title>Subway Map</title>
     <script type="text/javascript" src="https://code.jquery.com/jquery-1.9.0.min.js"></script>
-    <script type="text/javascript" src="jquery.subwayMap-0.5.0.js"></script>
+    <script type="text/javascript" src="jquery.subwayMap-0.5.1.js"></script>
     <style type="text/css">
     body
     {

--- a/subwayMap.htm
+++ b/subwayMap.htm
@@ -2,7 +2,7 @@
 <head>
     <title>Subway Map</title>
     <script type="text/javascript" src="https://code.jquery.com/jquery-1.9.0.min.js"></script>
-    <script type="text/javascript" src="jquery.subwayMap-0.5.1.js"></script>
+    <script type="text/javascript" src="jquery.subwayMap-0.5.2.js"></script>
     <style type="text/css">
     body
     {
@@ -51,7 +51,7 @@
 </head>
 <body>
     <div class="subway-map" data-columns="12" data-rows="10" data-cellSize="40" data-legendId="legend" data-textClass="text" data-gridNumbers="true" data-grid="false" data-lineWidth="8">
-        <ul data-color="#36AEFF" data-label="jQuery Widgets">          
+        <ul data-color="#36AEFF" data-label="jQuery Widgets" data-dotted="true">          
             <li data-coords="2,2" data-marker="interchange"><a href="http://jqueryui.com/demos/accordion/">Accordion</a></li>  
             <li data-coords="4,2"><a href="http://jqueryui.com/demos/autocomplete/"><a href="http://jqueryui.com/demos/autocomplete/">Auto\ncomplete</a></li>  
             <li data-coords="5,3" data-dir="E"></li>  

--- a/subwayMap.htm
+++ b/subwayMap.htm
@@ -51,7 +51,7 @@
 </head>
 <body>
     <div class="subway-map" data-columns="12" data-rows="10" data-cellSize="40" data-legendId="legend" data-textClass="text" data-gridNumbers="true" data-grid="false" data-lineWidth="8">
-        <ul data-color="#36AEFF" data-label="jQuery Widgets" data-dotted="true">          
+        <ul data-color="#36AEFF" data-label="jQuery Widgets">          
             <li data-coords="2,2" data-marker="interchange"><a href="http://jqueryui.com/demos/accordion/">Accordion</a></li>  
             <li data-coords="4,2"><a href="http://jqueryui.com/demos/autocomplete/"><a href="http://jqueryui.com/demos/autocomplete/">Auto\ncomplete</a></li>  
             <li data-coords="5,3" data-dir="E"></li>  
@@ -72,7 +72,7 @@
             <li data-coords="2,6"><a href="http://jqueryui.com/demos/tabs/">Tabs</a></li>  
         </ul>
 
-        <ul data-color="#FF7936 " data-label="jQuery Interactions" data-shiftCoords="0,-1" data-outline="true">      
+        <ul data-color="#FF7936 " data-label="jQuery Interactions" data-shiftCoords="0,-1" data-outline="true" data-dotted="true">      
             <li data-coords="2,6"></li> 
             <li data-coords="2,5.9" data-marker="@interchange"> </li> <!-- marker-only node, moved up by 0.10 -->
             <li data-coords="5,6" data-marker="@station" data-labelPos="N"><a href="http://jqueryui.com/demos/selectable/">Selectable</a></li>  


### PR DESCRIPTION
Hello,
I switched to SVG for the legend elements generation so it can take the "outline" param into account.
Tested on FF and Chrome 

Also changed colors to blue and orange 

![image](https://user-images.githubusercontent.com/1822081/50080441-5e72c400-01ec-11e9-970c-021d6a7fb4f7.png)

Also fixed `data-dotted` option, now set on `ul` element and working : 

![image](https://user-images.githubusercontent.com/1822081/50102208-c1804d00-0224-11e9-8a8c-c5f5a83939cc.png)




